### PR TITLE
feat: 添加 shouldOutput 配置选项并更新包信息

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "auto-copilot-context",
-  "version": "0.2.1",
+  "name": "auto-context",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto-copilot-context",
-      "version": "0.2.1",
+      "name": "auto-context",
+      "version": "0.2.6",
       "dependencies": {
         "@types/mocha": "^10.0.3",
         "@types/node": "18.x",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "activationEvents": [
     "onLanguage"
-  ], 
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -50,33 +50,38 @@
             }
           },
           "default": [
-        {
-            "path": "output/opened-files.xml",
-            "format": "<Opened Files>\n<File Name>\n${fileName}\n</File Name>\n<File Content>\n${content}\n</File Content>\n</Opened Files>\n",
-            "prependContent": ""
-        },
-        {
-            "path": ".cursor/rules/opened-files.mdc",
-            "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
-            "prependContent": "---\ndescription: \nglobs: \nalwaysApply: true\n---"
-        },
-        {
-            "path": ".roo/rules/opened-files.md",
-            "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
-            "prependContent": ""
-        },
-        {
-            "path": ".clinerules/opened-files.md",
-            "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
-            "prependContent": ""
-        }
-    ],
+            {
+              "path": "output/opened-files.xml",
+              "format": "<Opened Files>\n<File Name>\n${fileName}\n</File Name>\n<File Content>\n${content}\n</File Content>\n</Opened Files>\n",
+              "prependContent": ""
+            },
+            {
+              "path": ".cursor/rules/opened-files.mdc",
+              "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
+              "prependContent": "---\ndescription: \nglobs: \nalwaysApply: true\n---"
+            },
+            {
+              "path": ".roo/rules/opened-files.md",
+              "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
+              "prependContent": ""
+            },
+            {
+              "path": ".clinerules/opened-files.md",
+              "format": "# Opened Files\n## File Name\n${fileName}\n## File Content\n${content}\n",
+              "prependContent": ""
+            }
+          ],
           "description": "List of output configurations, each specifying a path and format for context output"
         },
         "autoContext.shouldOutput": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to output the context file when files change"
+          "type": "string",
+          "enum": [
+            "always",
+            "gitRepOnly",
+            "never"
+          ],
+          "default": "gitRepOnly",
+          "description": "When to output the context file: 'always' for all cases, 'gitRepOnly' only in git repositories, 'never' to disable"
         },
         "autoContext.ignorePinnedTabs": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "auto-copilot-context",
   "description": "",
   "icon": "auto-copilot-context.png",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "engines": {
     "vscode": "^1.84.0"
   },

--- a/src/core/ContextTracker.ts
+++ b/src/core/ContextTracker.ts
@@ -57,7 +57,7 @@ export class ContextTracker {
   }
 
   private handleFileChange(): void {
-    if (!this.config.shouldOutput) {
+    if (!this.configManager.shouldOutput()) {
       return;
     }
     try {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -17,7 +17,7 @@ export interface OutputConfig {
 // 扩展配置接口
 export interface ExtensionConfig {
   outputList: OutputConfig[];
-  shouldOutput: boolean;
+  shouldOutput: 'always' | 'gitRepOnly' | 'never';
   ignorePinnedTabs: boolean;
 }
 
@@ -46,4 +46,5 @@ export interface IOutputWriter {
 // 配置管理器接口
 export interface IConfigurationManager {
   getConfiguration(): ExtensionConfig;
+  shouldOutput(): boolean;
 }


### PR DESCRIPTION
## Summary
- 添加 shouldOutput 配置选项，支持三种模式控制上下文输出行为
- 更新包名称为 auto-context，版本升级至 0.2.6
- 重构配置管理逻辑，增强灵活性

## Changes
### 新功能
- **shouldOutput 配置选项**: 支持 'always'、'gitRepOnly'、'never' 三种模式
  - `always`: 始终输出上下文文件
  - `gitRepOnly`: 仅在 git 仓库中输出
  - `never`: 禁用输出

### 配置更新
- 包名称从 `auto-copilot-context` 更新为 `auto-context`
- 版本从 0.2.4 升级至 0.2.6
- 默认配置改为 `gitRepOnly` 模式

### 代码重构
- `ConfigurationManager`: 新增 `shouldOutput()` 方法和 `isGitRepository()` 检测
- `ContextTracker`: 更新输出逻辑，使用新的配置管理方式
- 完善测试用例，覆盖新的配置选项

## Test plan
- [x] 测试三种 shouldOutput 模式的行为
- [x] 验证 git 仓库检测功能
- [x] 确保向下兼容性
- [x] 运行完整测试套件

🤖 Generated with [Claude Code](https://claude.ai/code)